### PR TITLE
FIX: XML writer document ending

### DIFF
--- a/src/main/java/fr/lille1/idl/stackoverflow/processors/XMLWriter.java
+++ b/src/main/java/fr/lille1/idl/stackoverflow/processors/XMLWriter.java
@@ -34,7 +34,7 @@ public class XMLWriter implements XMLEventProcessor {
 
     public void close() throws XMLStreamException {
         if (writer != null) {
-            XMLEvent endElement = this.eventFactory.createStartElement(new QName("posts"), null, null);
+            XMLEvent endElement = this.eventFactory.createEndElement(new QName("posts"), null);
             this.writer.add(endElement);
             this.writer.flush();
             this.writer.close();

--- a/src/test/java/fr/lille1/idl/stackoverflow/processors/XMLWriterTest.java
+++ b/src/test/java/fr/lille1/idl/stackoverflow/processors/XMLWriterTest.java
@@ -1,0 +1,45 @@
+package fr.lille1.idl.stackoverflow.processors;
+
+import org.junit.Test;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by dorian on 30/11/14.
+ */
+public class XMLWriterTest {
+    @Test
+    public void testXMLIsValid() throws IOException, XMLStreamException {
+        File file = File.createTempFile("test", "xml");
+        String filename = System.getProperty("java.io.tmpdir") + File.separator + "so-exctractor.xml";
+        try {
+            XMLWriter writer = new XMLWriter(file.getAbsolutePath());
+            writer.close();
+        } catch (XMLStreamException unexpected) {
+            fail(unexpected.getMessage());
+        }
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+        FileInputStream fis = new FileInputStream(file);
+        XMLEventReader reader = inputFactory.createXMLEventReader(fis);
+        //Read XML header
+        reader.nextEvent();
+        XMLEvent openingPostTag = reader.nextEvent();
+        assertTrue(openingPostTag.isStartElement());
+        assertEquals(openingPostTag.asStartElement().getName().toString(), "posts");
+        XMLEvent closingPostTag = reader.nextEvent();
+        assertTrue(closingPostTag.isEndElement());
+        assertEquals(closingPostTag.asEndElement().getName().toString(), "posts");
+        assertEquals("enddocument", reader.nextEvent().toString().toLowerCase());
+        reader.close();
+        fis.close();
+        file.delete();
+    }
+}


### PR DESCRIPTION
Fixed a bug where the XML writer would end the document with an opening
<posts> tag in place of a closing </posts> tag.
